### PR TITLE
Update satnogs_fetch.py to use oresat-configs 0.7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # oresat-random-scripts
 A place to share random scripts
+
+## Setup
+Install python dependencies with `pip install .`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools >= 77.0.3"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "oresat-random-scripts"
+version = "0.1"
+dependencies = [
+  "oresat-configs==0.7.2",
+  "requests"
+]
+
+[tool.setuptools]
+# We don't want to build a real package from the scripts (yet)
+packages=[]

--- a/satnogs_fetch.py
+++ b/satnogs_fetch.py
@@ -7,7 +7,7 @@ from time import sleep
 
 import canopen
 import requests
-from oresat_configs import OreSatConfig, OreSatId
+from oresat_configs import OreSatConfig, Consts
 
 OUT_FILE = "beacons.csv"
 SAT_ID = "DKCD-1609-0567-7056-3922"  # OreSat0.5
@@ -29,7 +29,7 @@ DATA_TYPE_SIZE = {
     canopen.objectdictionary.datatypes.UNSIGNED64: 8,
 }
 
-beacon_def = OreSatConfig(OreSatId.ORESAT0_5).beacon_def
+beacon_def = OreSatConfig(Consts.ORESAT0_5).beacon_def
 
 data = []
 


### PR DESCRIPTION
The currently released oresat-configs version. That version removed the OreSatId enum whose functionality was subsumed by the Consts dataclass. When releasing I tried to update all projects that used oresat-configs but I missed this one.

While here I've added a pyproject.toml for recording dependencies. Since we don't (yet) want to actually build a package I've told setuptools not to produce one, just have pip do the dependencies only.