### PR TITLE
Add circuitpython build/flash script

### DIFF
--- a/cirpy-flash
+++ b/cirpy-flash
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# This script requires you to download circuitpython's custom mpy-cross compiler
+# NOT the pip package mpy-cross, which is micropython specific
+
+TARGET_DIR="/run/media/$USER/CIRCUITPY"
+GREEN='\e[0;32m'
+BLUE='\e[0;34m'
+RED='\033[1;31m'
+NC='\e[0m' # No Color (reset)
+
+# Check that mpy-cross is installed
+if ! command -v mpy-cross >/dev/null 2>&1
+then
+  echo -e "${RED}Error:$NC Circuitpython's mpy-cross must be installed" >&2
+  exit 1
+fi
+
+# Create the build dir if it doesn't exist already
+if [ ! -d "./build" ]; then
+  mkdir build
+fi
+
+# Build
+for py_file in *.py; do
+  if [ ! py_file = "main.py" ]; then
+    echo -e "Building ${BLUE}${py_file}${NC}"
+    base=${py_file%.*} # remove the '.py' extension
+    mpy-cross $py_file -o ./build/${base}.mpy
+  fi
+done
+
+# Check if the board is plugged in
+if [ ! -d "$TARGET_DIR" ]; then
+  echo -e "${RED}Error:$NC Board not found" >&2
+  exit 1
+fi
+
+echo -e "Flashing ${BLUE}main.py$NC to $BLUE$TARGET_DIR$NC"
+cp main.py $TARGET_DIR
+
+for file in "build/"*.mpy; do
+  # flash to lib dir
+  echo -e "Flashing $BLUE$file$NC to $BLUE$location$NC"
+  cp $file $TARGET_DIR/lib
+done
+
+echo "Syncing..."
+sync # Linux must sync to actually write the files
+
+echo -e "${GREEN}Done${NC}"

--- a/cirpy-flash
+++ b/cirpy-flash
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-# This script requires you to download circuitpython's custom mpy-cross compiler
+# This script is only tested with circuitpython's custom mpy-cross compiler
 # NOT the pip package mpy-cross, which is micropython specific
+# It may work with micropython, but there is no guarantee
 
 TARGET_DIR="/run/media/$USER/CIRCUITPY"
 GREEN='\e[0;32m'
@@ -23,7 +24,7 @@ fi
 
 # Build
 for py_file in *.py; do
-  if [ ! py_file = "main.py" ]; then
+  if [ "$py_file" != "main.py" ]; then
     echo -e "Building ${BLUE}${py_file}${NC}"
     base=${py_file%.*} # remove the '.py' extension
     mpy-cross $py_file -o ./build/${base}.mpy
@@ -40,9 +41,10 @@ echo -e "Flashing ${BLUE}main.py$NC to $BLUE$TARGET_DIR$NC"
 cp main.py $TARGET_DIR
 
 for file in "build/"*.mpy; do
+  lib_dir=$TARGET_DIR/lib
   # flash to lib dir
-  echo -e "Flashing $BLUE$file$NC to $BLUE$location$NC"
-  cp $file $TARGET_DIR/lib
+  echo -e "Flashing $BLUE$file$NC to $BLUE$lib_dir$NC"
+  cp $file $lib_dir
 done
 
 echo "Syncing..."


### PR DESCRIPTION
This script will compile any files with a .py extension EXCEPT any file named main.py. It will create if necessary a dir named build and output the compiled files to that dir. It will then check if there is a device at /run/media/$USER/CIRCUITPY and cp over the compiled files to its /lib dir, and main.py to the root dir. Then it syncs the filesystem.